### PR TITLE
create a main config file inside the root

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -7,7 +7,7 @@ extension-pkg-whitelist=
 
 # Add files or directories to the blacklist. They should be base names, not
 # paths.
-ignore=CVS
+ignore=CVS,__init__.py,config.cfg,.pylintrc
 
 # Add files or directories matching the regex patterns to the blacklist. The
 # regex matches against base names, not paths.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Once you have completed these steps you should be able to:
 * Run `pytest` from the root of the project
 * Run `pytest` from `tests/`
 * Run `main.py` from anywhere (e.g. `python src/python_structure/main.py`)
-* Run `pylint` from anywhere in the project
+* Run `pylint` from the root directory of the project
 
 
 ## Files and Directories
@@ -42,7 +42,8 @@ Once you have completed these steps you should be able to:
 
 ## Pylint
 
-* Command to run pylint: `pylint mymodule.py`
+* When running Pylint, run the command while in the root directory of the project
+* Command to run pylint: `pylint tests/*.py src`
 * Pylint config file name is `.pylintrc`
 * Pylint can only run recursively through directories if they are included in the Python package
 * Pylint uses the config file in the folder from where it is called


### PR DESCRIPTION
Created a main config file for pylint to be run at the root directory of the project. All pylint commands must be made from this location in order to use the correct configuration file.